### PR TITLE
Optimisation (Without temp-file)

### DIFF
--- a/only_errors.sh
+++ b/only_errors.sh
@@ -1,3 +1,1 @@
-norminette | egrep -B1 'Error|Warning' > .check.txt
-cat .check.txt | sed ''/Error/s//$(printf "\033[31m\033[4mError\033[0m")/'' | sed ''/Warning/s//$(printf "\033[33m\033[4mWarning\033[0m")/''
-rm .check.txt
+norminette | egrep -B1 'Error|Warning' | sed ''/Error/s//$(printf "\033[31m\033[4mError\033[0m")/'' | sed ''/Warning/s//$(printf "\033[33m\033[4mWarning\033[0m")/''


### PR DESCRIPTION
**# Optimisation**

` > .check.txt - cat .check.txt` 

> Partie inutile.

Modification supprimant la création d'un ficher temporaire pour ensuite le lire
(Prendra moins de place pour un lancement de la commande "norminette" sur un grand projet (par exemple un libft amélioré).